### PR TITLE
Allows publishing to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,5 @@
   "files": [
     "lib"
   ],
-  "license": "UNLICENSED",
-  "private": true
+  "license": "UNLICENSED"
 }


### PR DESCRIPTION
Turns out that `private: true` in `package.json` prevent publishing to any repository, including private ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable/2)
<!-- Reviewable:end -->
