### PR TITLE
Release v1.0.1 - Fixes 404 error with official airtable-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualifyze/airtable",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualifyze/airtable",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A more powerful airtable client",
   "main": "lib/index.js",
   "scripts": {

--- a/src/official-client-wrapper.ts
+++ b/src/official-client-wrapper.ts
@@ -22,7 +22,7 @@ export class OfficialClientWrapper implements Endpoint {
     const { statusCode, headers, body } = await this.officialClient.makeRequest(
       {
         method,
-        path: path === null ? undefined : path,
+        path: path === null ? undefined : `/${path}`,
         qs: payload?.query,
         body: payload?.body,
       }


### PR DESCRIPTION
This releases a fix for fatal error that deprecated v1.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable/42)
<!-- Reviewable:end -->
