### PR TITLE
Fix table methods

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -96,7 +96,9 @@ export class Table<Fields extends UnknownFields>
     const data = await this.runTableAction("POST", {
       responseValidation: new MultiRecordDataValidation(this),
       payload: {
-        body: { records },
+        body: {
+          records: records.map((record) => ({ fields: record })),
+        },
       },
     });
 
@@ -116,14 +118,7 @@ export class Table<Fields extends UnknownFields>
   private async updateSingleRecord(
     data: RecordData<Fields>
   ): Promise<AirtableRecord<Fields>> {
-    const response = await this.runTableAction("PATCH", {
-      responseValidation: new RecordDataValidation(this),
-      payload: {
-        body: data,
-      },
-    });
-
-    return AirtableRecord.fromRecordData(this, response);
+    return new AirtableRecord(this, data.id).update(data.fields);
   }
 
   private async updateMultipleRecords(
@@ -142,14 +137,7 @@ export class Table<Fields extends UnknownFields>
   private async replaceSingleRecord(
     data: RecordData<Fields>
   ): Promise<AirtableRecord<Fields>> {
-    const response = await this.runTableAction("PUT", {
-      responseValidation: new RecordDataValidation(this),
-      payload: {
-        body: data,
-      },
-    });
-
-    return AirtableRecord.fromRecordData(this, response);
+    return new AirtableRecord(this, data.id).replace(data.fields);
   }
 
   private async replaceMultipleRecords(


### PR DESCRIPTION
## What

Fixed table methods to create multiple records and update/replace single ones.

## Why

The mentioned methods throw HTTP 422 and analysis shows the issue in `src/table.ts`.

## How

- table methods to update a single record are switched to the ones on the record level
- payload structure for creation method is fixed according to [Airtable API documentation](https://airtable.com/appekiuXc1nu3ourc/api/docs#curl/table:auditee:create)

## Testing

Done with the script from PR #60.

## Who is affected

All the users of the package in a way that some method calls start to modify the data instead of throwing the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable/61)
<!-- Reviewable:end -->
