### PR TITLE
Make record data non-nullable

### DIFF
--- a/.changeset/pretty-tigers-turn.md
+++ b/.changeset/pretty-tigers-turn.md
@@ -1,0 +1,8 @@
+---
+"@qualifyze/airtable": major
+---
+
+[BREAKING CHANGE] Make AirtableRecord.data non-nullable.
+It's always an object once any operation is executed, and it's inconvenient
+to cast it to non-nullable in the calling code. The consumers should check
+their code for `AirtableRecord` constructor or `data` property usage.

--- a/integration.ts
+++ b/integration.ts
@@ -71,7 +71,7 @@ const main = async () => {
     console.log("Checking record.fetch...");
 
     validateRecord(
-      await new AirtableRecord(table, singleRecord.id).fetch(),
+      await new AirtableRecord(table, singleRecord.id, {}).fetch(),
       singleRecord
     );
 
@@ -98,7 +98,7 @@ const main = async () => {
     console.log("Checking with record.fetch for non-existing record...");
 
     await validateNotFound(() =>
-      new AirtableRecord(table, singleRecord.id).fetch()
+      new AirtableRecord(table, singleRecord.id, {}).fetch()
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualifyze/airtable",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1218,6 +1218,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
+    },
+    "@types/airtable": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@types/airtable/-/airtable-0.10.1.tgz",
+      "integrity": "sha512-ZwMU+ZztgmN1k12ist39+lDQAkeeaPLO5pgXdRodJecVTMo+zKHNn83dQcLY3eaD3BbUfEZ/6uJsqBTcM+UKuQ==",
+      "dev": true,
+      "requires": {
+        "airtable": "*"
+      }
     },
     "@types/babel__core": {
       "version": "7.1.14",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.0",
     "@changesets/cli": "^2.16.0",
+    "@types/airtable": "^0.10.1",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.2",
     "airtable": "^0.10.1",

--- a/src/record-draft.ts
+++ b/src/record-draft.ts
@@ -1,0 +1,81 @@
+import { FieldsValidator, UnknownFields } from "./fields";
+import { ActionPointOptions } from "./action-point";
+import { RestMethod, UnknownActionPayload } from "./endpoint";
+import {
+  RecordDataValidation,
+  DeletedRecord,
+  DeletedRecordValidation,
+} from "./raw-types";
+import { TableActionPoint } from "./table";
+import { AirtableRecord } from "./record";
+
+export type RecordDataSource<Fields extends UnknownFields> = TableActionPoint &
+  FieldsValidator<Fields>;
+
+export interface RecordActionPoint {
+  runRecordAction<P extends UnknownActionPayload, R>(
+    method: RestMethod,
+    { path, ...options }: ActionPointOptions<P, R>
+  ): Promise<R>;
+}
+
+export class AirtableRecordDraft<Fields extends UnknownFields>
+  implements RecordActionPoint
+{
+  public readonly source: RecordDataSource<Fields>;
+  public readonly id: string;
+
+  constructor(source: RecordDataSource<Fields>, id: string) {
+    this.source = source;
+    this.id = id;
+  }
+
+  runRecordAction<P extends UnknownActionPayload, R>(
+    method: RestMethod,
+    { path, ...options }: ActionPointOptions<P, R>
+  ): Promise<R> {
+    return this.source.runTableAction(method, {
+      path: path ? `${this.id}/${path}` : this.id,
+      ...options,
+    });
+  }
+
+  async fetch(): Promise<AirtableRecord<Fields>> {
+    const { fields } = await this.runRecordAction("GET", {
+      responseValidation: new RecordDataValidation(this.source),
+    });
+    return new AirtableRecord(this.source, this.id, fields);
+  }
+
+  async update(data: Fields): Promise<AirtableRecord<Fields>> {
+    const { id, fields } = await this.runRecordAction("PATCH", {
+      responseValidation: new RecordDataValidation(this.source),
+      payload: {
+        body: {
+          fields: data,
+        },
+      },
+    });
+
+    return new AirtableRecord(this.source, id, fields);
+  }
+
+  async replace(data: Fields): Promise<AirtableRecord<Fields>> {
+    const { id, fields } = await this.runRecordAction("PUT", {
+      responseValidation: new RecordDataValidation(this.source),
+      payload: {
+        body: {
+          fields: data,
+        },
+      },
+    });
+
+    return new AirtableRecord(this.source, id, fields);
+  }
+
+  destroy(): Promise<DeletedRecord> {
+    return this.runRecordAction("DELETE", {
+      responseValidation: new DeletedRecordValidation(),
+    });
+  }
+}

--- a/src/record.ts
+++ b/src/record.ts
@@ -1,31 +1,11 @@
-import { FieldsValidator, UnknownFields } from "./fields";
-import { ActionPointOptions } from "./action-point";
-import { RestMethod, UnknownActionPayload } from "./endpoint";
-import {
-  RecordData,
-  RecordDataValidation,
-  DeletedRecord,
-  DeletedRecordValidation,
-  MultiRecordData,
-} from "./raw-types";
-import { TableActionPoint } from "./table";
+import { UnknownFields } from "./fields";
+import { RecordData, MultiRecordData } from "./raw-types";
+import { AirtableRecordDraft, RecordDataSource } from "./record-draft";
 
-export type RecordDataSource<Fields extends UnknownFields> = TableActionPoint &
-  FieldsValidator<Fields>;
-
-export interface RecordActionPoint {
-  runRecordAction<P extends UnknownActionPayload, R>(
-    method: RestMethod,
-    { path, ...options }: ActionPointOptions<P, R>
-  ): Promise<R>;
-}
-
-export class AirtableRecord<Fields extends UnknownFields>
-  implements RecordActionPoint
-{
-  public readonly source: RecordDataSource<Fields>;
-  public readonly id: string;
-  public readonly data?: Readonly<Fields>;
+export class AirtableRecord<
+  Fields extends UnknownFields
+> extends AirtableRecordDraft<Fields> {
+  public readonly data: Readonly<Fields>;
 
   static fromRecordData<Fields extends UnknownFields>(
     source: RecordDataSource<Fields>,
@@ -41,58 +21,8 @@ export class AirtableRecord<Fields extends UnknownFields>
     return records.map((data) => this.fromRecordData(source, data));
   }
 
-  constructor(source: RecordDataSource<Fields>, id: string, data?: Fields) {
-    this.source = source;
-    this.id = id;
+  constructor(source: RecordDataSource<Fields>, id: string, data: Fields) {
+    super(source, id);
     this.data = data;
-  }
-
-  runRecordAction<P extends UnknownActionPayload, R>(
-    method: RestMethod,
-    { path, ...options }: ActionPointOptions<P, R>
-  ): Promise<R> {
-    return this.source.runTableAction(method, {
-      path: path ? `${this.id}/${path}` : this.id,
-      ...options,
-    });
-  }
-
-  async fetch(): Promise<AirtableRecord<Fields>> {
-    const { fields } = await this.runRecordAction("GET", {
-      responseValidation: new RecordDataValidation(this.source),
-    });
-    return new AirtableRecord(this.source, this.id, fields);
-  }
-
-  async update(data: Fields): Promise<AirtableRecord<Fields>> {
-    const { id, fields } = await this.runRecordAction("PATCH", {
-      responseValidation: new RecordDataValidation(this.source),
-      payload: {
-        body: {
-          fields: data,
-        },
-      },
-    });
-
-    return new AirtableRecord(this.source, id, fields);
-  }
-
-  async replace(data: Fields): Promise<AirtableRecord<Fields>> {
-    const { id, fields } = await this.runRecordAction("PUT", {
-      responseValidation: new RecordDataValidation(this.source),
-      payload: {
-        body: {
-          fields: data,
-        },
-      },
-    });
-
-    return new AirtableRecord(this.source, id, fields);
-  }
-
-  destroy(): Promise<DeletedRecord> {
-    return this.runRecordAction("DELETE", {
-      responseValidation: new DeletedRecordValidation(),
-    });
   }
 }

--- a/src/table.ts
+++ b/src/table.ts
@@ -3,6 +3,7 @@ import { ActionPoint, ActionPointOptions } from "./action-point";
 import { ValidationContext } from "./validator";
 import { RestMethod, UnknownActionPayload } from "./endpoint";
 import { AirtableRecord } from "./record";
+import { AirtableRecordDraft } from "./record-draft";
 import { SelectQuery, SelectQueryParams } from "./select-query";
 
 import { RecordData, RecordDataValidation } from "./raw-types";
@@ -70,7 +71,7 @@ export class Table<Fields extends UnknownFields>
   }
 
   find(recordId: string): Promise<AirtableRecord<Fields>> {
-    return new AirtableRecord(this, recordId).fetch();
+    return new AirtableRecordDraft(this, recordId).fetch();
   }
 
   select(query: SelectQueryParams<Fields> = {}): SelectQuery<Fields> {
@@ -118,7 +119,7 @@ export class Table<Fields extends UnknownFields>
   private async updateSingleRecord(
     data: RecordData<Fields>
   ): Promise<AirtableRecord<Fields>> {
-    return new AirtableRecord(this, data.id).update(data.fields);
+    return new AirtableRecordDraft(this, data.id).update(data.fields);
   }
 
   private async updateMultipleRecords(
@@ -137,7 +138,7 @@ export class Table<Fields extends UnknownFields>
   private async replaceSingleRecord(
     data: RecordData<Fields>
   ): Promise<AirtableRecord<Fields>> {
-    return new AirtableRecord(this, data.id).replace(data.fields);
+    return new AirtableRecordDraft(this, data.id).replace(data.fields);
   }
 
   private async replaceMultipleRecords(
@@ -173,7 +174,7 @@ export class Table<Fields extends UnknownFields>
   }
 
   private destroySingleRecord(id: string): Promise<DeletedRecord> {
-    return new AirtableRecord(this, id).destroy();
+    return new AirtableRecordDraft(this, id).destroy();
   }
 
   private async destroyMultipleRecords(


### PR DESCRIPTION
## What

Make `AirtableRecord.data` non-nullable.

## Why

`AirtableRecord.data` is always an object once any operation is executed and it's inconvenient to cast it to non-nullable in the calling code.

## How

Add a base class `AirtableRecordDraft` which contains the record id and not the data.

## Testing

```
npm run integration
```

## Who is affected

Breaking change as `data` argument of `AirtableRecord` constructor is now required.

## Remarks

`AirtableRecordDraft` might give an idea that it holds the data and it's just not saved yet. Though I'm not sure what name would be better. As an option we could consider removing the usage of `AirtableRecord` operations from `Table` class instead of the intermediate class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable/73)
<!-- Reviewable:end -->
