### PR TITLE
Run tests on each commit and assigning PR

### DIFF
--- a/.changeset/eight-donuts-lay.md
+++ b/.changeset/eight-donuts-lay.md
@@ -1,5 +1,0 @@
----
-"@qualifyze/airtable": patch
----
-
-Run test workflow only for a PR.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 name: Test
 on:
+  push: { }
+  # Trigger this workflow on PRs created by Changesets by assigning it to
+  # someone. We need this workaround because PRs created by GitHub Actions do
+  # not trigger workflows per default.
   pull_request:
     branches: [ main ]
+    types: [ assigned ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -169,3 +169,7 @@ it describes.
 Each PR with changeset files merged into the main branch will open/update PR
 to release the package with the proper version. Merging that PR will bump the version,
 create a GitHub release and publish the new version to the npm registry.
+
+Unfortunately, the test workflow required to merge a PR is not triggered by
+the version PR. The workaround is assigning PR to yourself which is added as
+an additional trigger for the test workflow.


### PR DESCRIPTION
## What

Run tests on each commit and assigning PR. This reverts some changes done in #77.

## Why

It might be useful to know the testing status for each commit.

GitHub does not allow the workflow to easily run another workflow. Since changesets are based on a GitHub action, their version PR does not trigger the test workflow which is required to merge a PR. So the workaround is to trigger it manually by assigning PR to yourself.

## How

Updated the triggers for the test workflow.

## Testing

Once this PR is merged, the version PR will be updated. Then someone need to change its assignment and wait for the test workflow to unblock the merge operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable/79)
<!-- Reviewable:end -->
