### PR TITLE
Bugfix: use partial type for the update operations

### DIFF
--- a/.changeset/tall-rivers-clap.md
+++ b/.changeset/tall-rivers-clap.md
@@ -1,0 +1,5 @@
+---
+"@qualifyze/airtable": patch
+---
+
+Bugfix: use partial type for the update operations to align with Airtable API.

--- a/src/record-draft.ts
+++ b/src/record-draft.ts
@@ -47,7 +47,7 @@ export class AirtableRecordDraft<Fields extends UnknownFields>
     return new AirtableRecord(this.source, this.id, fields);
   }
 
-  async update(data: Fields): Promise<AirtableRecord<Fields>> {
+  async update(data: Partial<Fields>): Promise<AirtableRecord<Fields>> {
     const { id, fields } = await this.runRecordAction("PATCH", {
       responseValidation: new RecordDataValidation(this.source),
       payload: {

--- a/src/table.ts
+++ b/src/table.ts
@@ -117,13 +117,13 @@ export class Table<Fields extends UnknownFields>
   }
 
   private async updateSingleRecord(
-    data: RecordData<Fields>
+    data: RecordData<Partial<Fields>>
   ): Promise<AirtableRecord<Fields>> {
     return new AirtableRecordDraft(this, data.id).update(data.fields);
   }
 
   private async updateMultipleRecords(
-    data: RecordData<Fields>[]
+    data: RecordData<Partial<Fields>>[]
   ): Promise<AirtableRecord<Fields>[]> {
     const response = await this.runTableAction("PATCH", {
       responseValidation: new MultiRecordDataValidation(this),
@@ -153,10 +153,12 @@ export class Table<Fields extends UnknownFields>
     return AirtableRecord.fromMultiRecordData(this, response);
   }
 
-  update(data: RecordData<Fields>): Promise<AirtableRecord<Fields>>;
-  update(data: RecordData<Fields>[]): Promise<AirtableRecord<Fields>[]>;
+  update(data: RecordData<Partial<Fields>>): Promise<AirtableRecord<Fields>>;
+  update(
+    data: RecordData<Partial<Fields>>[]
+  ): Promise<AirtableRecord<Fields>[]>;
   async update(
-    data: RecordData<Fields> | RecordData<Fields>[]
+    data: RecordData<Partial<Fields>> | RecordData<Partial<Fields>>[]
   ): Promise<AirtableRecord<Fields> | AirtableRecord<Fields>[]> {
     return Array.isArray(data)
       ? this.updateMultipleRecords(data)


### PR DESCRIPTION
Full type is necessary only for creation and replacing.
Tested with the original `npm run integration` and its typed variation.