### PR TITLE
Removes references to NPM secerts in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,17 @@
-  # This file is managed in the repository Qualifyze/dev-infrastructure
-  # New updates of this file on  Qualifyze/dev-infrastructure will automatically trigger new pull requests to up this file here
-  # You can still add small amendments here, but if any larger divergence is necessary, then it would be recommended
-  # to either disable this push-template in Qualifyze/dev-infrastructure, or if this change is applicable to all repositories,
-  # edit it here https://github.com/Qualifyze/dev-infrastructure/blob/main/templates/dependabot-npm.
 version: 2
+
 updates:
-  - package-ecosystem: npm
-    registries:
-      - npm-npmjs
-    directory: '/'
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
-    open-pull-requests-limit: 20
-    reviewers:
-      - 'Qualifyze/dev-people'
-registries:
-  npm-npmjs:
-    type: npm-registry
-    url: https://registry.npmjs.org
-    token: ${{ secrets.NPM_TOKEN }}
+      interval: daily
+    # Disable version updates; security ones are not affected
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    # Disable version updates; security ones are not affected
+    open-pull-requests-limit: 0
+


### PR DESCRIPTION
# What❓

Removed configuration of private NPM repos for dependabot.

# Why 💁‍♀️

This is a public repo using public NPM packages only. There is no access to any private NPM repos.

This will fix automated dependabot PRs.

# Todos before it can be reviewed

The things that need to be completed before this can be reviewed:

<!-- add check boxes here, or remove this section -->

None

# Todos before it can be merged

The things that need to be completed before this PR can be merged:

<!-- add check boxes here, or remove this section -->

None
