### PR TITLE
Dependabot Fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,8 @@ updates:
 
   - package-ecosystem: npm
     directory: /
-    registries: [npmjs]
     schedule:
       interval: daily
     # Disable version updates; security ones are not affected
     open-pull-requests-limit: 0
 
-registries:
-  npmjs:
-    type: npm-registry
-    url: https://registry.npmjs.org
-    token: ${{ secrets.NPM_READER_TOKEN }}


### PR DESCRIPTION
# What❓

Removed configuration of private NPM repos for dependabot.

# Why 💁‍♀️

This is a public repo using public NPM packages only. There is no access to any private NPM repos.

This will fix automated dependabot PRs.

# Todos before it can be reviewed

The things that need to be completed before this can be reviewed:

<!-- add check boxes here, or remove this section -->

None

# Todos before it can be merged

The things that need to be completed before this PR can be merged:

<!-- add check boxes here, or remove this section -->

None

